### PR TITLE
Update ImageCore and ImageMorphology

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.3', '1', 'nightly']
+        julia-version: ['1.6', '1', 'nightly']
         os: [ubuntu-latest]
         arch: [x64]
         include:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImagePhaseCongruency"
 uuid = "10e51d30-6ba1-539a-b97e-c69c597142c4"
 authors = ["Peter Kovesi <peter.kovesi@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -11,6 +11,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 FFTW = "1"
-ImageCore = "0.9, 0.10"
-ImageMorphology = "0.3, 0.4"
-julia = "1.3"
+ImageCore = "0.10"
+ImageMorphology = "0.4"
+julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 FFTW = "1"
-ImageCore = "0.10"
+ImageCore = "0.9, 0.10"
 ImageMorphology = "0.4"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 FFTW = "1"
-ImageCore = "0.9"
-ImageMorphology = "0.3"
+ImageCore = "0.9, 0.10"
+ImageMorphology = "0.3, 0.4"
 julia = "1.3"

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -18,7 +18,7 @@ PK August 2015
    October 2018 Julia 0.7/1.0
 
 ---------------------------------------------------------------------=#
-import ImageMorphology: label_components, component_indices
+import ImageMorphology: label_components, component_indices, strel_box
 export replacenan, fillnan
 export hysthresh, imgnormalize
 
@@ -116,7 +116,6 @@ threshold T2 are also marked as edges. Eight connectivity is used.
 
 """
 function hysthresh(img::AbstractArray{T0,2}, T1::Real, T2::Real) where T0 <: Real
-
     bw = falses(size(img))
 
     if T1 < T2    # Swap T1 and T2
@@ -125,13 +124,14 @@ function hysthresh(img::AbstractArray{T0,2}, T1::Real, T2::Real) where T0 <: Rea
 
     # Form 8-connected components of pixels with a value above the
     # lower threshold and get the indices of pixels in each component.
-    label = label_components(img .>= T2, trues(3,3))
+    label = label_components(img .>= T2, strel_box((3, 3)))
     pix = component_indices(label)
+    num_non_background_labels = length(pix) - 1
 
     # For each list of pixels in pix test to see if there are any
     # image values above T1.  If so, set these pixels in the output
     # image.  Note we ignore pix[1] as these are the background pixels.
-    for n = 2:length(pix)
+    for n = 1:num_non_background_labels
         for i in eachindex(pix[n])
             if img[pix[n][i]] >= T1
                 bw[pix[n]] .= true

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -41,5 +41,11 @@ img[15:20,15] .= 10
 img[15,15] = 20
 
 bw = hysthresh(img, 8, 20)
+
+expected_img = falses(30,30)
+expected_img[15:20, 15] .= true
+
+@test all(bw .== expected_img)
+
 if disp; imshow(img); title("Unthresholded image"); mypause(); end
 if disp; imshow(bw); title("Thresholded image"); mypause(); end


### PR DESCRIPTION
Update the ImageCore and ImageMorphology dependencies to v0.10 and v0.4, respectively.

ImageMorphology v0.4 now uses OffsetArrays for component label arrays that index from 0 and supports structuring elements. All tests ran without issue except for those related to `hysthresh`.
1. updated `hysthresh` to use `strel_box` and to handle new label array
2. added a test for `hysthresh`

As far as I can tell, all of the other functions are working normally. However, I'm not an expert so some review may be necessary.

Thanks! Love using this package.